### PR TITLE
Use Azure queue and table for storage

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -3,7 +3,7 @@ ALLOWED_EMAIL_DOMAINS=scvsar.org,rtreit.com
 ALLOWED_ADMIN_USERS="randy@example.com,alice@example.com"
 
 # Storage
-STORAGE_ACCOUNT_NAME=
+AZURE_STORAGE_CONNECTION_STRING=
 STORAGE_TABLE_NAME=ResponderMessages
 STORAGE_QUEUE_NAME=respondr-incoming
 

--- a/backend/STORAGE_CONFIG.md
+++ b/backend/STORAGE_CONFIG.md
@@ -1,13 +1,12 @@
 # Storage Configuration Guide
 
-Respondr now supports multiple storage backends with automatic fallback capabilities.
+Respondr uses Azure Table Storage for persistence with optional file or in-memory fallback.
 
 ## Environment Variables
 
 ### Primary Storage Backend
 Set `STORAGE_BACKEND` to choose your primary storage:
-- `redis` (default) - Use Redis for storage
-- `azure_table` - Use Azure Table Storage
+- `azure_table` (default) - Use Azure Table Storage
 - `file` - Use JSON files on disk
 - `memory` - Use in-memory storage (not persistent)
 
@@ -15,12 +14,6 @@ Set `STORAGE_BACKEND` to choose your primary storage:
 Set `STORAGE_FALLBACK` to choose fallback when primary fails:
 - `memory` (default) - Use in-memory storage as fallback
 - `file` - Use JSON files as fallback
-- `redis` - Use Redis as fallback (if primary is not redis)
-
-### Redis Configuration
-- `REDIS_HOST` - Redis server hostname (default: localhost)
-- `REDIS_PORT` - Redis server port (default: 6379)
-- `REDIS_DB` - Redis database number (default: 0)
 
 ### Azure Table Storage Configuration
 - `AZURE_STORAGE_CONNECTION_STRING` - Azure Storage connection string
@@ -32,15 +25,7 @@ Set `STORAGE_FALLBACK` to choose fallback when primary fails:
 
 ## Example Configurations
 
-### Redis Primary, Memory Fallback (Default)
-```bash
-STORAGE_BACKEND=redis
-STORAGE_FALLBACK=memory
-REDIS_HOST=localhost
-REDIS_PORT=6379
-```
-
-### Azure Table Primary, File Fallback
+### Azure Table Primary, File Fallback (Default)
 ```bash
 STORAGE_BACKEND=azure_table
 STORAGE_FALLBACK=file
@@ -83,5 +68,4 @@ to avoid conflicts with production data.
 
 ## Migration Notes
 
-This new storage system is backwards compatible with existing Redis-based storage.
-All existing functions continue to work unchanged.
+Redis support has been removed. Azure Table Storage is now the primary persistence mechanism.

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -56,12 +56,6 @@ def now_tz() -> datetime:
     return datetime.now(APP_TZ)
 
 
-# Redis configuration
-REDIS_HOST = os.getenv("REDIS_HOST", "redis-service")
-REDIS_PORT = int(os.getenv("REDIS_PORT", "6379"))
-REDIS_DB = int(os.getenv("REDIS_DB", "0"))
-REDIS_KEY = "respondr_messages"
-REDIS_DELETED_KEY = "respondr_deleted_messages"
 
 # Authentication and authorization
 webhook_api_key = os.getenv("WEBHOOK_API_KEY")

--- a/backend/app/queue_listener.py
+++ b/backend/app/queue_listener.py
@@ -1,0 +1,45 @@
+"""Background task to process messages from Azure Storage Queue."""
+
+import asyncio
+import json
+import logging
+import os
+
+from azure.storage.queue import QueueClient
+
+from .routers.webhook import WebhookMessage, webhook_handler
+
+logger = logging.getLogger(__name__)
+
+
+async def listen_to_queue() -> None:
+    """Continuously poll Azure Storage Queue and process messages."""
+    conn_str = os.getenv("AZURE_STORAGE_CONNECTION_STRING")
+    queue_name = os.getenv("STORAGE_QUEUE_NAME")
+
+    if not conn_str or not queue_name:
+        logger.warning("Queue connection not configured; skipping listener")
+        return
+
+    queue = QueueClient.from_connection_string(conn_str, queue_name)
+
+    while True:
+        try:
+            messages = await asyncio.to_thread(
+                queue.receive_messages, messages_per_page=5, visibility_timeout=30
+            )
+            for msg in messages:
+                try:
+                    payload = json.loads(msg.content)
+                    web_msg = WebhookMessage(**payload)
+                    await webhook_handler(web_msg, request=None, debug=False)
+                except Exception:
+                    logger.exception("Failed processing queue message")
+                finally:
+                    await asyncio.to_thread(queue.delete_message, msg)
+        except Exception:
+            logger.exception("Queue polling failed")
+            await asyncio.sleep(5)
+
+        await asyncio.sleep(1)
+

--- a/backend/app/routers/acr.py
+++ b/backend/app/routers/acr.py
@@ -160,7 +160,7 @@ def get_pod_info():
 @router.post("/cleanup/invalid-timestamps")
 def cleanup_invalid_timestamps():
     """Clean up messages with invalid timestamp formats."""
-    # This endpoint would need access to Redis storage layer
+    # This endpoint would need access to the storage layer
     # For now, return a placeholder response
     logger.info("Cleanup invalid timestamps endpoint called")
     return {

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,16 +6,12 @@ python-dotenv>=1.0.0
 openai>=1.0.0
 python-multipart>=0.0.6
 requests>=2.31.0
-redis>=5.0.0
-python-dotenv
 aiofiles
-requests
-redis>=4.0.0
 azure-data-tables>=12.4.0
+azure-storage-queue
 pytest
 pytest-asyncio
 httpx
 pytest-cov
 kubernetes>=29.0.0
 tzdata>=2024.1
-azure-data-tables

--- a/backend/test_storage.py
+++ b/backend/test_storage.py
@@ -2,8 +2,8 @@
 """
 Storage Fallback Test Script
 
-This script demonstrates the new storage abstraction layer with automatic fallback.
-It tests different scenarios including Redis unavailable and storage switching.
+This script demonstrates the storage abstraction layer with automatic fallback.
+It tests different scenarios including storage switching.
 """
 
 import os
@@ -81,7 +81,7 @@ def test_storage_fallback():
     print("Current storage configuration:")
     print_storage_status()
     
-    print(f"\nSTORAGE_BACKEND env var: {os.getenv('STORAGE_BACKEND', 'redis')}")
+    print(f"\nSTORAGE_BACKEND env var: {os.getenv('STORAGE_BACKEND', 'azure_table')}")
     print(f"STORAGE_FALLBACK env var: {os.getenv('STORAGE_FALLBACK', 'memory')}")
     
     # Test message persistence
@@ -109,7 +109,7 @@ def test_different_backends():
     print_section("Testing Different Backend Configurations")
     
     configs = [
-        ("Redis Primary, Memory Fallback", "redis", "memory"),
+        ("Azure Table Primary, File Fallback", "azure_table", "file"),
         ("Memory Primary, File Fallback", "memory", "file"),
         ("File Primary, Memory Fallback", "file", "memory"),
     ]

--- a/backend/tests/test_coverage_analysis.md
+++ b/backend/tests/test_coverage_analysis.md
@@ -4,7 +4,7 @@
 
 ### 1. **Message Processing & Storage**
 - ✅ **Storage Layer** (`app/storage.py`)
-  - Redis-based message persistence
+  - Azure Table–based message persistence
   - In-memory fallback for testing
   - CRUD operations: get, add, update, delete messages
   - Soft delete functionality
@@ -71,11 +71,11 @@
 #### 1. **Storage Layer Testing**
 ```python
 # Missing: tests/test_storage.py
-- Redis connection and fallback testing
+- Azure Table connection and fallback testing
 - CRUD operation validation
 - Soft delete functionality
 - Data persistence and retrieval
-- Error handling for Redis failures
+- Error handling for storage failures
 ```
 
 #### 2. **LLM Processing Testing**
@@ -132,7 +132,7 @@
 
 #### A. **Storage Comprehensive Testing**
 ```python
-def test_redis_connection_handling()
+def test_storage_connection_handling()
 def test_storage_crud_operations()
 def test_soft_delete_workflow()
 def test_bulk_operations()

--- a/backend/tests/test_storage_working.py
+++ b/backend/tests/test_storage_working.py
@@ -21,14 +21,6 @@ class TestStorageInterface:
         assert hasattr(storage, 'add_message')
         assert hasattr(storage, 'update_message')
         assert hasattr(storage, 'delete_message')
-        assert hasattr(storage, 'get_redis_client')
-
-    def test_redis_client_creation(self):
-        """Test Redis client creation logic."""
-        # Test in testing mode
-        with patch('app.storage.is_testing', True):
-            client = storage.get_redis_client()
-            assert client is None  # Should return None in testing mode
 
     def test_get_messages_with_mocked_import(self):
         """Test get_messages when in testing mode with proper mocking."""
@@ -138,26 +130,6 @@ class TestStorageInterface:
                         
                         assert result is True
 
-    def test_in_memory_fallback_with_redis_disabled(self):
-        """Test that in-memory storage works as fallback when Redis is disabled."""
-        # When Redis is not available, and we mock get_messages to avoid main import
-        with patch('app.storage.get_redis_client', return_value=None):
-            with patch('app.storage.get_messages', return_value=[]):
-                # Test that we can call functions without errors
-                result = storage.get_redis_client()
-                assert result is None
-
-    def test_storage_error_handling(self):
-        """Test error handling in storage operations."""
-        # Test with Redis client that raises exceptions
-        mock_redis = MagicMock()
-        mock_redis.get.side_effect = Exception("Redis error")
-        
-        with patch('app.storage.get_redis_client', return_value=mock_redis):
-            with patch('app.storage.is_testing', False):  # Not in testing mode
-                # Should handle the error gracefully and return empty list
-                messages = storage.get_messages()
-                assert messages == []
 
     def test_bulk_operations_logic(self):
         """Test logic for bulk operations."""

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,13 +1,4 @@
 services:
-  redis:
-    image: redis:7-alpine
-    ports:
-      - "6379:6379"
-    restart: unless-stopped
-    command: redis-server --appendonly yes
-    volumes:
-      - redis_data:/data
-
   respondr:
     build:
       context: .
@@ -16,15 +7,12 @@ services:
       - "8000:8000"
     environment:
       - DEBUG=true
-      - REDIS_HOST=redis
-  - DISABLE_API_KEY_CHECK=true
+      - DISABLE_API_KEY_CHECK=true
     env_file:
       - backend/.env
     volumes:
       - ./backend:/app:ro  # Read-only for security
     restart: unless-stopped
-    depends_on:
-      - redis
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/api/responders"]
       interval: 30s
@@ -44,5 +32,3 @@ services:
     profiles:
       - nginx  # Only start with --profile nginx
 
-volumes:
-  redis_data:

--- a/functions/groupme_ingest/__init__.py
+++ b/functions/groupme_ingest/__init__.py
@@ -4,6 +4,10 @@ import os
 
 import azure.functions as func
 from azure.storage.queue import QueueClient
+from dotenv import load_dotenv
+
+# Load environment variables from .env for local testing
+load_dotenv()
 
 
 def main(req: func.HttpRequest) -> func.HttpResponse:

--- a/functions/requirements.txt
+++ b/functions/requirements.txt
@@ -1,2 +1,3 @@
 azure-functions
 azure-storage-queue
+python-dotenv


### PR DESCRIPTION
## Summary
- load environment variables via `dotenv` in Azure Function for local testing
- poll Azure Storage Queue in backend and process messages without Redis
- drop Redis support and rely on Azure Table Storage

## Testing
- `pytest backend/tests -q` *(fails: KeyError 'confidence', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68aa04f99bf48330bfcd47cb11423092