### PR TITLE
Prevent duplicate responder rows during queue retries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -56,10 +56,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
 
@@ -79,7 +79,7 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,10 +82,10 @@ jobs:
         uses: actions/checkout@v5
       
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
@@ -102,7 +102,7 @@ jobs:
           echo "Generated tags: ${TAGS}"
       
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile.backend

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -48,19 +48,19 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Validate shared agent artifacts
         shell: pwsh
         run: ./scripts/test-agent-artifacts.ps1
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "20"
           cache: npm

--- a/.github/workflows/deploy-preprod.yml
+++ b/.github/workflows/deploy-preprod.yml
@@ -93,14 +93,14 @@ jobs:
       # Upload test results if tests fail (optional)
       - name: Upload backend test results
         if: failure()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: backend-test-results
           path: backend/htmlcov/
       
       - name: Upload frontend coverage
         if: always()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: frontend-coverage
           path: frontend/coverage/

--- a/.github/workflows/deploy-preprod.yml
+++ b/.github/workflows/deploy-preprod.yml
@@ -121,11 +121,11 @@ jobs:
       
       # Set up Docker Buildx for advanced build features
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       
       # Log in to Docker Hub
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
@@ -158,7 +158,7 @@ jobs:
       
       # Build and push Docker image
       - name: Build and push Docker image (preprod channel)
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile.backend
@@ -171,7 +171,7 @@ jobs:
       
       # Log in to Azure using OIDC (federated credentials)
       - name: Azure Login
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ env.AZURE_CLIENT_ID }}
           tenant-id: ${{ env.AZURE_TENANT_ID }}

--- a/.github/workflows/deploy-preprod.yml
+++ b/.github/workflows/deploy-preprod.yml
@@ -28,23 +28,23 @@ jobs:
     steps:
       # Checkout the repository code
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       
       # Set up Python for backend tests
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       
       # Set up Node.js for frontend tests
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
       
       # Cache Python dependencies
       - name: Cache Python dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('backend/requirements.txt') }}
@@ -53,7 +53,7 @@ jobs:
       
       # Cache Node modules
       - name: Cache Node modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: frontend/node_modules
           key: ${{ runner.os }}-node-${{ hashFiles('frontend/package-lock.json') }}
@@ -93,14 +93,14 @@ jobs:
       # Upload test results if tests fail (optional)
       - name: Upload backend test results
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: backend-test-results
           path: backend/htmlcov/
       
       - name: Upload frontend coverage
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: frontend-coverage
           path: frontend/coverage/
@@ -117,7 +117,7 @@ jobs:
     steps:
       # Checkout the repository code
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       
       # Set up Docker Buildx for advanced build features
       - name: Set up Docker Buildx
@@ -247,7 +247,7 @@ jobs:
 
       # Build and deploy Static Web App
       - name: Set up Node.js for SWA
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
 

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -43,22 +43,22 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
 
       - name: Cache Python dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('backend/requirements.txt') }}
@@ -66,7 +66,7 @@ jobs:
             ${{ runner.os }}-pip-
 
       - name: Cache Node modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: frontend/node_modules
           key: ${{ runner.os }}-node-${{ hashFiles('frontend/package-lock.json') }}
@@ -106,7 +106,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Resolve parameters
         id: params
@@ -263,7 +263,7 @@ jobs:
           echo "Static Web App deployment will continue." >> $GITHUB_STEP_SUMMARY
 
       - name: Set up Node.js for SWA
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
 

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -169,11 +169,11 @@ jobs:
 
       - name: Set up Docker Buildx
         if: steps.backend_decision.outputs.backend_deploy == 'true' && steps.params.outputs.image_tag == ''
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Docker Hub
         if: steps.backend_decision.outputs.backend_deploy == 'true' && steps.params.outputs.image_tag == ''
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
@@ -186,7 +186,7 @@ jobs:
 
       - name: Build and push Docker image (prod)
         if: steps.backend_decision.outputs.backend_deploy == 'true' && steps.params.outputs.image_tag == ''
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile.backend
@@ -210,7 +210,7 @@ jobs:
 
       - name: Azure Login
         if: steps.backend_decision.outputs.backend_deploy == 'true'
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ env.AZURE_CLIENT_ID }}
           tenant-id: ${{ env.AZURE_TENANT_ID }}

--- a/backend/app/queue_listener.py
+++ b/backend/app/queue_listener.py
@@ -4,13 +4,55 @@ import asyncio
 import json
 import logging
 import os
-from typing import Optional
+from typing import Any, Dict, Optional
 
 from azure.storage.queue import QueueClient
 
 from .routers.webhook import WebhookMessage, webhook_handler
 
 logger = logging.getLogger(__name__)
+
+DEFAULT_VISIBILITY_TIMEOUT_SECONDS = 300
+DEFAULT_VISIBILITY_RENEWAL_SECONDS = 120
+
+
+def _positive_int_setting(name: str, default: int) -> int:
+    """Read a positive integer setting."""
+    raw_value = os.getenv(name, "").strip()
+    if not raw_value:
+        return default
+
+    try:
+        value = int(raw_value)
+    except ValueError:
+        logger.warning("Invalid %s setting; using %s", name, default)
+        return default
+
+    if value < 1:
+        logger.warning("Invalid %s setting; using %s", name, default)
+        return default
+
+    return value
+
+
+def _queue_timing_settings() -> tuple[int, int]:
+    """Return the visibility timeout and renewal interval."""
+    visibility_timeout = _positive_int_setting(
+        "QUEUE_VISIBILITY_TIMEOUT_SECONDS",
+        DEFAULT_VISIBILITY_TIMEOUT_SECONDS,
+    )
+    renewal_interval = _positive_int_setting(
+        "QUEUE_VISIBILITY_RENEWAL_SECONDS",
+        DEFAULT_VISIBILITY_RENEWAL_SECONDS,
+    )
+    if renewal_interval >= visibility_timeout:
+        renewal_interval = max(1, visibility_timeout // 2)
+        logger.warning(
+            "Queue visibility renewal must be shorter than the timeout; using %s",
+            renewal_interval,
+        )
+
+    return visibility_timeout, renewal_interval
 
 
 def _get_queue_api_version(conn_str: str) -> Optional[str]:
@@ -66,6 +108,76 @@ async def ensure_queue_exists(queue: QueueClient, queue_name: str) -> bool:
                 return False
 
 
+async def _renew_message_visibility(
+    queue: QueueClient,
+    message_state: Dict[str, Any],
+    stop_event: asyncio.Event,
+    visibility_timeout: int,
+    renewal_interval: int,
+) -> None:
+    """Renew one message lease until processing stops."""
+    while not stop_event.is_set():
+        try:
+            await asyncio.wait_for(stop_event.wait(), timeout=renewal_interval)
+            return
+        except asyncio.TimeoutError:
+            updated_message = await asyncio.to_thread(
+                queue.update_message,
+                message_state["message"],
+                visibility_timeout=visibility_timeout,
+            )
+            message_state["message"] = updated_message
+            logger.debug("Renewed queue message visibility")
+
+
+async def process_queue_message(
+    queue: QueueClient,
+    message: Any,
+    visibility_timeout: int,
+    renewal_interval: int,
+) -> bool:
+    """Process and delete one queue message."""
+    message_state: Dict[str, Any] = {"message": message}
+    stop_event = asyncio.Event()
+    renewal_task = asyncio.create_task(
+        _renew_message_visibility(
+            queue,
+            message_state,
+            stop_event,
+            visibility_timeout,
+            renewal_interval,
+        )
+    )
+    processing_success = False
+
+    try:
+        payload = json.loads(message.content)
+        web_msg = WebhookMessage(**payload)
+        await webhook_handler(web_msg, request=None, debug=False)
+        processing_success = True
+    except Exception:
+        logger.exception("Failed processing queue message")
+    finally:
+        stop_event.set()
+        try:
+            await renewal_task
+        except Exception:
+            logger.exception("Failed to renew queue message visibility")
+
+    if not processing_success:
+        return False
+
+    try:
+        await asyncio.to_thread(
+            queue.delete_message,
+            message_state["message"],
+        )
+        return True
+    except Exception:
+        logger.exception("Failed to delete processed message")
+        return False
+
+
 async def listen_to_queue() -> None:
     """Continuously poll Azure Storage Queue and process messages."""
     conn_str = os.getenv("AZURE_STORAGE_CONNECTION_STRING")
@@ -93,27 +205,23 @@ async def listen_to_queue() -> None:
     else:
         logger.warning("Queue is not accessible, will retry periodically...")
 
+    visibility_timeout, renewal_interval = _queue_timing_settings()
+
     while True:
         try:
             messages = await asyncio.to_thread(
-                queue.receive_messages, messages_per_page=5, visibility_timeout=30
+                queue.receive_messages,
+                messages_per_page=1,
+                max_messages=1,
+                visibility_timeout=visibility_timeout,
             )
             for msg in messages:
-                processing_success = False
-                try:
-                    payload = json.loads(msg.content)
-                    web_msg = WebhookMessage(**payload)
-                    await webhook_handler(web_msg, request=None, debug=False)
-                    processing_success = True
-                except Exception:
-                    logger.exception("Failed processing queue message")
-                    # Don't delete failed messages - let them retry after visibility timeout
-                finally:
-                    if processing_success:
-                        try:
-                            await asyncio.to_thread(queue.delete_message, msg)
-                        except Exception:
-                            logger.exception("Failed to delete processed message")
+                await process_queue_message(
+                    queue,
+                    msg,
+                    visibility_timeout,
+                    renewal_interval,
+                )
         except Exception as e:
             error_msg = str(e).lower()
             if "not found" in error_msg or "does not exist" in error_msg:

--- a/backend/app/routers/webhook.py
+++ b/backend/app/routers/webhook.py
@@ -1,13 +1,14 @@
 """Webhook and message parsing endpoints."""
 
+import hashlib
 import logging
+import uuid
 from datetime import datetime, timezone
 from fastapi import APIRouter, HTTPException, Depends, Query, Request
 from fastapi.concurrency import run_in_threadpool
 from fastapi.responses import JSONResponse
 from typing import Dict, Any, Optional
 from pydantic import BaseModel
-import uuid
 
 from ..config import webhook_api_key, disable_api_key_check, APP_TZ, GROUP_ID_TO_TEAM
 from ..llm import extract_details_from_text, build_prompts
@@ -47,6 +48,19 @@ class ParseDebugRequest(BaseModel):
     prev_eta_iso: Optional[str] = None
 
 
+def _build_storage_message_id(
+    group_id: Optional[str],
+    source_message_id: Optional[str],
+) -> str:
+    """Build an Azure Table-safe stable ID for a source message."""
+    if not source_message_id:
+        return str(uuid.uuid4())
+
+    identity = f"{group_id or 'unknown'}:{source_message_id}"
+    digest = hashlib.sha256(identity.encode("utf-8")).hexdigest()
+    return f"groupme-{digest}"
+
+
 def verify_api_key(api_key: Optional[str] = None):
     """Verify API key for webhook endpoints."""
     if disable_api_key_check:
@@ -71,11 +85,32 @@ async def webhook_handler(message: WebhookMessage, request: Request, debug: bool
         group_id = message.group_id or "unknown"
         team = GROUP_ID_TO_TEAM.get(group_id, "Unknown")
         name_l = (message.name or "").strip().lower()
+        storage_message_id = _build_storage_message_id(group_id, message.id)
 
         # Look up previous ETA for this responder (same group) to allow persistence on updates
         prev_eta_iso: Optional[str] = None
         try:
             history = get_messages() or []
+            existing_message = next(
+                (
+                    item
+                    for item in history
+                    if item.get("id") == storage_message_id
+                ),
+                None,
+            )
+            if existing_message is not None:
+                logger.info(
+                    "Skipped duplicate GroupMe message %s",
+                    storage_message_id[:20],
+                )
+                if debug:
+                    return {
+                        "status": "duplicate",
+                        "stored_message": existing_message,
+                    }
+                return {"status": "duplicate"}
+
             # Sort latest first; prefer same group_id and same name
             # Look for the most recent ETA that was actually calculated (not inherited)
             for m in sorted(history, key=lambda x: x.get("created_at", 0), reverse=True):
@@ -280,7 +315,7 @@ async def webhook_handler(message: WebhookMessage, request: Request, debug: bool
         if isinstance(minutes, int) and minutes <= 0 and arrival_status == "Responding":
             arrival_status = "Arrived"
         new_message = {
-            "id": str(uuid.uuid4()),
+            "id": storage_message_id,
             "groupme_id": message.id,  # Store GroupMe message ID for debugging
             "name": message.name,
             "text": message.text,
@@ -299,9 +334,10 @@ async def webhook_handler(message: WebhookMessage, request: Request, debug: bool
             "group_id": group_id,
             "created_at": message.created_at,
         }
-        
+
         # Store message in storage layer
-        add_message(new_message)
+        if not add_message(new_message):
+            raise RuntimeError("Failed to save responder message")
         logger.info(
             f"Processed webhook message from {message.name}: {parsed['vehicle']} ETA {parsed['eta']}"
             + (f" (prev_eta carried)" if prev_eta_iso else "")

--- a/backend/app/storage.py
+++ b/backend/app/storage.py
@@ -200,6 +200,61 @@ class StorageManager:
                 return self.save_messages(messages)  # Recursive retry with fallback
             
             return False
+
+    def add_message(self, message: Dict[str, Any]) -> bool:
+        """Add or replace one active message."""
+
+        if is_testing:
+            import main
+            messages = getattr(main, "messages", _test_messages)
+            message_id = message.get("id")
+            if message_id:
+                messages[:] = [
+                    item for item in messages if item.get("id") != message_id
+                ]
+            messages.append(message)
+            return True
+
+        self._ensure_backend()
+
+        try:
+            backend = self.current_backend
+            assert backend is not None
+
+            success = backend.add_message(message)
+            if success:
+                logger.debug(
+                    "Saved message %s to %s",
+                    message.get("id", "unknown"),
+                    backend.backend_type.value,
+                )
+            else:
+                logger.warning(
+                    "Failed to save message %s to %s",
+                    message.get("id", "unknown"),
+                    backend.backend_type.value,
+                )
+                if (
+                    self.current_backend == self.primary_backend
+                    and self.fallback_backend
+                ):
+                    logger.warning(
+                        "Switching to fallback storage for add operation"
+                    )
+                    self.current_backend = self.fallback_backend
+                    return self.add_message(message)
+            return success
+        except Exception as e:
+            backend = self.current_backend
+            backend_name = backend.backend_type.value if backend else "unknown"
+            logger.error(f"Failed to add message to {backend_name}: {e}")
+
+            if self.current_backend == self.primary_backend and self.fallback_backend:
+                logger.warning("Switching to fallback storage for add operation")
+                self.current_backend = self.fallback_backend
+                return self.add_message(message)
+
+            return False
     
     def get_deleted_messages(self) -> List[Dict[str, Any]]:
         """Get all deleted messages from storage."""
@@ -311,10 +366,8 @@ def get_storage_info() -> Dict[str, Any]:
 
 # Legacy functions that might be used by other parts of the codebase
 def add_message(message: Dict[str, Any]):
-    """Add a new message."""
-    messages = get_messages()
-    messages.append(message)
-    save_messages(messages)
+    """Add or replace one message."""
+    return _storage_manager.add_message(message)
 
 
 def delete_message(msg_id: str) -> bool:

--- a/backend/app/storage_backends.py
+++ b/backend/app/storage_backends.py
@@ -32,6 +32,15 @@ class BaseStorage(ABC):
     def save_messages(self, messages: List[Dict[str, Any]]) -> bool:
         """Save all active messages. Returns True on success."""
         pass
+
+    def add_message(self, message: Dict[str, Any]) -> bool:
+        """Add or replace one active message."""
+        messages = self.get_messages()
+        message_id = message.get("id")
+        if message_id:
+            messages = [item for item in messages if item.get("id") != message_id]
+        messages.append(message)
+        return self.save_messages(messages)
     
     @abstractmethod
     def get_deleted_messages(self) -> List[Dict[str, Any]]:
@@ -68,6 +77,15 @@ class MemoryStorage(BaseStorage):
     
     def save_messages(self, messages: List[Dict[str, Any]]) -> bool:
         self._messages = messages.copy()
+        return True
+
+    def add_message(self, message: Dict[str, Any]) -> bool:
+        message_id = message.get("id")
+        if message_id:
+            self._messages = [
+                item for item in self._messages if item.get("id") != message_id
+            ]
+        self._messages.append(message.copy())
         return True
     
     def get_deleted_messages(self) -> List[Dict[str, Any]]:
@@ -122,6 +140,14 @@ class FileStorage(BaseStorage):
     
     def save_messages(self, messages: List[Dict[str, Any]]) -> bool:
         return self._write_json_file(self.messages_file, messages)
+
+    def add_message(self, message: Dict[str, Any]) -> bool:
+        messages = self.get_messages()
+        message_id = message.get("id")
+        if message_id:
+            messages = [item for item in messages if item.get("id") != message_id]
+        messages.append(message)
+        return self.save_messages(messages)
     
     def get_deleted_messages(self) -> List[Dict[str, Any]]:
         return self._read_json_file(self.deleted_file)
@@ -298,6 +324,25 @@ class AzureTableStorage(BaseStorage):
         except Exception as e:
             logger.error(f"Failed to get messages from Azure Table Storage: {e}")
             raise
+
+    def add_message(self, message: Dict[str, Any]) -> bool:
+        """Atomically add or replace one active message."""
+        if not self.is_healthy() or self._client is None:
+            return False
+
+        message_id = message.get("id")
+        if not message_id:
+            logger.error("Cannot save a message without an id")
+            return False
+
+        try:
+            table_client = self._client.get_table_client(self.table_name)
+            entity = self._message_to_entity(message, "messages")
+            table_client.upsert_entity(entity)
+            return True
+        except Exception as e:
+            logger.error(f"Failed to save message {message_id}: {e}")
+            return False
     
     def save_messages(self, messages: List[Dict[str, Any]]) -> bool:
         """Save all active messages to Azure Table Storage."""

--- a/backend/run_tests.py
+++ b/backend/run_tests.py
@@ -10,7 +10,9 @@ def main():
     
     # Run only our working test files to avoid hanging/broken tests
     working_tests = [
-        "tests/test_storage_working.py", 
+        "tests/test_storage_working.py",
+        "tests/test_queue_idempotency.py",
+        "tests/test_cleanup_duplicate_responders.py",
         "tests/test_main.py",
         "tests/test_retention.py"
     ]

--- a/backend/tests/test_cleanup_duplicate_responders.py
+++ b/backend/tests/test_cleanup_duplicate_responders.py
@@ -1,0 +1,128 @@
+"""Tests for the recoverable duplicate cleanup plan."""
+
+import importlib.util
+from pathlib import Path
+
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "scripts"
+    / "cleanup_duplicate_responders.py"
+)
+SPEC = importlib.util.spec_from_file_location(
+    "cleanup_duplicate_responders",
+    SCRIPT_PATH,
+)
+assert SPEC is not None and SPEC.loader is not None
+cleanup = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(cleanup)
+
+
+def test_cleanup_plan_keeps_one_entity_per_groupme_id():
+    entities = [
+        {
+            "PartitionKey": "messages",
+            "RowKey": "old-b",
+            "groupme_id": "source-1",
+        },
+        {
+            "PartitionKey": "messages",
+            "RowKey": "old-a",
+            "groupme_id": "source-1",
+        },
+        {
+            "PartitionKey": "messages",
+            "RowKey": "only",
+            "groupme_id": "source-2",
+        },
+    ]
+
+    plan = cleanup.build_cleanup_plan(entities)
+
+    assert len(plan) == 1
+    groupme_id, keeper, removals = plan[0]
+    assert groupme_id == "source-1"
+    assert keeper["RowKey"] == "old-a"
+    assert [entity["RowKey"] for entity in removals] == ["old-b"]
+
+
+def test_cleanup_plan_prefers_stable_groupme_row_key():
+    entities = [
+        {
+            "PartitionKey": "messages",
+            "RowKey": "000-old",
+            "groupme_id": "source-1",
+        },
+        {
+            "PartitionKey": "messages",
+            "RowKey": "groupme-stable",
+            "groupme_id": "source-1",
+        },
+    ]
+
+    plan = cleanup.build_cleanup_plan(entities)
+
+    assert plan[0][1]["RowKey"] == "groupme-stable"
+    assert plan[0][2][0]["RowKey"] == "000-old"
+
+
+def test_cleanup_plan_prefers_confident_complete_legacy_row():
+    entities = [
+        {
+            "PartitionKey": "messages",
+            "RowKey": "old-a",
+            "groupme_id": "source-1",
+            "status_confidence": 0.60,
+            "arrival_status": "Unknown",
+            "vehicle": "Unknown",
+            "eta": "Unknown",
+            "eta_timestamp": "Unknown",
+        },
+        {
+            "PartitionKey": "messages",
+            "RowKey": "old-b",
+            "groupme_id": "source-1",
+            "status_confidence": 0.95,
+            "arrival_status": "Responding",
+            "vehicle": "POV",
+            "eta": "20:15",
+            "eta_timestamp": "2026-07-23T20:15:00-07:00",
+        },
+    ]
+
+    plan = cleanup.build_cleanup_plan(entities)
+
+    assert plan[0][1]["RowKey"] == "old-b"
+    assert plan[0][2][0]["RowKey"] == "old-a"
+
+
+def test_copy_to_backup_preserves_data_and_records_origin():
+    table_client = type(
+        "TableClientStub",
+        (),
+        {"upsert_entity": lambda self, entity: setattr(self, "entity", entity)},
+    )()
+    entity = {
+        "PartitionKey": "messages",
+        "RowKey": "old-a",
+        "groupme_id": "source-1",
+        "text": "Responding",
+        "Timestamp": "service-managed",
+        "etag": "service-managed",
+    }
+
+    cleanup.copy_to_backup(
+        table_client,
+        entity,
+        "duplicate-cleanup-20260723",
+        "2026-07-23T20:00:00+00:00",
+    )
+
+    assert table_client.entity == {
+        "PartitionKey": "duplicate-cleanup-20260723",
+        "RowKey": "old-a",
+        "groupme_id": "source-1",
+        "text": "Responding",
+        "cleanup_original_partition": "messages",
+        "cleanup_time_utc": "2026-07-23T20:00:00+00:00",
+    }

--- a/backend/tests/test_queue_idempotency.py
+++ b/backend/tests/test_queue_idempotency.py
@@ -1,0 +1,192 @@
+"""Regression tests for duplicate GroupMe queue delivery."""
+
+import asyncio
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.queue_listener import process_queue_message
+from app.routers.webhook import (
+    WebhookMessage,
+    _build_storage_message_id,
+    webhook_handler,
+)
+from app.storage_backends import AzureTableStorage, MemoryStorage
+
+
+def _parsed_response():
+    return {
+        "vehicle": "POV",
+        "eta": "15 minutes",
+        "eta_timestamp": "2026-07-23 15:15:00",
+        "eta_timestamp_utc": "2026-07-23T22:15:00+00:00",
+        "minutes_until_arrival": 15,
+        "arrival_status": "Responding",
+        "raw_status": "Responding",
+        "status_source": "LLM",
+        "status_confidence": 0.99,
+    }
+
+
+def test_source_message_id_is_stable_and_scoped_to_group():
+    first = _build_storage_message_id("group-1", "message-1")
+    retry = _build_storage_message_id("group-1", "message-1")
+    other_group = _build_storage_message_id("group-2", "message-1")
+
+    assert first == retry
+    assert first != other_group
+    assert first.startswith("groupme-")
+
+
+def test_memory_storage_upserts_one_message_without_removing_others():
+    storage = MemoryStorage()
+    storage.add_message({"id": "stable-1", "text": "first"})
+    storage.add_message({"id": "stable-2", "text": "other"})
+    storage.add_message({"id": "stable-1", "text": "retry"})
+
+    messages = sorted(storage.get_messages(), key=lambda item: item["id"])
+
+    assert messages == [
+        {"id": "stable-1", "text": "retry"},
+        {"id": "stable-2", "text": "other"},
+    ]
+
+
+def test_azure_storage_add_message_uses_one_atomic_upsert():
+    table_client = MagicMock()
+    service_client = MagicMock()
+    service_client.get_table_client.return_value = table_client
+
+    storage = AzureTableStorage.__new__(AzureTableStorage)
+    storage.table_name = "ResponderMessages"
+    storage._client = service_client
+    storage._is_healthy_cached = True
+    storage._last_health_check = 0
+
+    with patch.object(storage, "is_healthy", return_value=True):
+        result = storage.add_message(
+            {
+                "id": "stable-1",
+                "groupme_id": "source-1",
+                "text": "synthetic",
+            }
+        )
+
+    assert result is True
+    table_client.upsert_entity.assert_called_once()
+    table_client.query_entities.assert_not_called()
+    table_client.delete_entity.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_duplicate_webhook_delivery_runs_extraction_once_and_stores_one_row():
+    stored_messages = []
+
+    def add_or_replace(message):
+        stored_messages[:] = [
+            item for item in stored_messages if item["id"] != message["id"]
+        ]
+        stored_messages.append(message)
+        return True
+
+    message = WebhookMessage(
+        id="source-message-1",
+        group_id="synthetic-group",
+        name="Synthetic Responder",
+        text="Responding in POV with ETA 15 minutes.",
+        created_at=1784844000,
+    )
+
+    with (
+        patch(
+            "app.routers.webhook.get_messages",
+            side_effect=lambda: list(stored_messages),
+        ),
+        patch(
+            "app.routers.webhook.add_message",
+            side_effect=add_or_replace,
+        ),
+        patch(
+            "app.routers.webhook.extract_details_from_text",
+            return_value=_parsed_response(),
+        ) as extract,
+    ):
+        first = await webhook_handler(message, request=None, debug=False)
+        retry = await webhook_handler(message, request=None, debug=False)
+
+    assert first == {"status": "ok"}
+    assert retry == {"status": "duplicate"}
+    assert len(stored_messages) == 1
+    assert stored_messages[0]["groupme_id"] == "source-message-1"
+    assert extract.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_slow_queue_processing_renews_visibility_and_deletes_latest_receipt():
+    payload = {
+        "id": "source-message-1",
+        "group_id": "synthetic-group",
+        "name": "Synthetic Responder",
+        "text": "Responding in POV with ETA 15 minutes.",
+        "created_at": 1784844000,
+    }
+    original = SimpleNamespace(
+        content=json.dumps(payload),
+        id="queue-message-1",
+        pop_receipt="receipt-0",
+    )
+    queue = MagicMock()
+    receipt_number = 0
+
+    def update_message(message, visibility_timeout):
+        nonlocal receipt_number
+        receipt_number += 1
+        return SimpleNamespace(
+            content=message.content,
+            id=message.id,
+            pop_receipt=f"receipt-{receipt_number}",
+        )
+
+    queue.update_message.side_effect = update_message
+
+    async def slow_handler(*args, **kwargs):
+        await asyncio.sleep(0.04)
+        return {"status": "ok"}
+
+    with patch(
+        "app.queue_listener.webhook_handler",
+        side_effect=slow_handler,
+    ):
+        result = await process_queue_message(
+            queue,
+            original,
+            visibility_timeout=2,
+            renewal_interval=0.01,
+        )
+
+    assert result is True
+    assert queue.update_message.call_count >= 1
+    deleted_message = queue.delete_message.call_args.args[0]
+    assert deleted_message.pop_receipt == f"receipt-{receipt_number}"
+
+
+@pytest.mark.asyncio
+async def test_failed_queue_processing_does_not_delete_message():
+    message = SimpleNamespace(
+        content="{invalid-json",
+        id="queue-message-1",
+        pop_receipt="receipt-0",
+    )
+    queue = MagicMock()
+
+    result = await process_queue_message(
+        queue,
+        message,
+        visibility_timeout=2,
+        renewal_interval=1,
+    )
+
+    assert result is False
+    queue.delete_message.assert_not_called()

--- a/backend/tests/test_storage_working.py
+++ b/backend/tests/test_storage_working.py
@@ -53,20 +53,15 @@ class TestStorageInterface:
             "timestamp": datetime.now(APP_TZ).isoformat()
         }
         
-        # Mock the storage functions to avoid Redis dependency
-        with patch('app.storage.get_messages', return_value=[]):
-            with patch('app.storage.save_messages') as mock_save:
-                # The add_message function doesn't return the message, it just adds it
-                storage.add_message(test_message)
-                
-                # Verify save_messages was called
-                mock_save.assert_called_once()
-                
-                # Check that the message was added to the list passed to save_messages
-                saved_messages = mock_save.call_args[0][0]
-                assert len(saved_messages) == 1
-                assert saved_messages[0]['name'] == test_message['name']
-                assert saved_messages[0]['text'] == test_message['text']
+        with patch.object(
+            storage._storage_manager,
+            "add_message",
+            return_value=True,
+        ) as mock_add:
+            result = storage.add_message(test_message)
+
+        assert result is True
+        mock_add.assert_called_once_with(test_message)
 
     def test_message_id_generation(self):
         """Test that messages can be processed without causing errors."""
@@ -75,13 +70,14 @@ class TestStorageInterface:
             "text": "Message without ID"
         }
         
-        with patch('app.storage.get_messages', return_value=[]):
-            with patch('app.storage.save_messages') as mock_save:
-                # Just test that the function works without errors
-                storage.add_message(test_message)
-                
-                # Verify it was called
-                mock_save.assert_called_once()
+        with patch.object(
+            storage._storage_manager,
+            "add_message",
+            return_value=True,
+        ) as mock_add:
+            assert storage.add_message(test_message) is True
+
+        mock_add.assert_called_once_with(test_message)
 
     def test_message_timestamp_generation(self):
         """Test that messages can be added without timestamps."""
@@ -90,13 +86,14 @@ class TestStorageInterface:
             "text": "Message without timestamp"
         }
         
-        with patch('app.storage.get_messages', return_value=[]):
-            with patch('app.storage.save_messages') as mock_save:
-                # Just test that the function works
-                storage.add_message(test_message)
-                
-                # Verify save was called
-                mock_save.assert_called_once()
+        with patch.object(
+            storage._storage_manager,
+            "add_message",
+            return_value=True,
+        ) as mock_add:
+            assert storage.add_message(test_message) is True
+
+        mock_add.assert_called_once_with(test_message)
 
     def test_update_message_logic(self):
         """Test update message functionality."""

--- a/frontend/public/staticwebapp.config.json
+++ b/frontend/public/staticwebapp.config.json
@@ -24,19 +24,6 @@
       "statusCode": 302
     }
   },
-  "auth": {
-    "rolesSource": "/api/user",
-    "identityProviders": {
-      "azureActiveDirectory": {
-        "userDetailsClaim": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name",
-        "registration": {
-          "openIdIssuer": "https://login.microsoftonline.com/common/v2.0",
-          "clientIdSettingName": "AZURE_CLIENT_ID",
-          "clientSecretSettingName": "AZURE_CLIENT_SECRET"
-        }
-      }
-    }
-  },
   "forwardingGateway": {
     "requiredHeaders": {
       "X-Azure-FDID": ""

--- a/scripts/cleanup_duplicate_responders.py
+++ b/scripts/cleanup_duplicate_responders.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Move duplicate responder entities to a recovery partition."""
+
+import argparse
+import os
+import sys
+from collections import defaultdict
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, List, Tuple
+
+from azure.core.credentials import AzureNamedKeyCredential
+from azure.data.tables import TableClient
+
+
+ACTIVE_PARTITION = "messages"
+SYSTEM_FIELDS = {"PartitionKey", "RowKey", "Timestamp", "etag"}
+UNKNOWN_VALUES = {"", "none", "not specified", "unknown"}
+
+
+def _confidence(entity: Dict[str, Any]) -> float:
+    """Return a sortable confidence value."""
+    try:
+        return float(entity.get("status_confidence", 0))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _completeness(entity: Dict[str, Any]) -> int:
+    """Count useful extracted responder fields."""
+    fields = ("arrival_status", "vehicle", "eta", "eta_timestamp")
+    return sum(
+        str(entity.get(field, "")).strip().lower() not in UNKNOWN_VALUES
+        for field in fields
+    )
+
+
+def _timestamp(entity: Dict[str, Any]) -> float:
+    """Return the Azure entity update time as a sortable value."""
+    value = entity.get("Timestamp")
+    if isinstance(value, datetime):
+        return value.timestamp()
+    if value:
+        try:
+            return datetime.fromisoformat(str(value).replace("Z", "+00:00")).timestamp()
+        except ValueError:
+            pass
+    return 0
+
+
+def select_keeper(entities: Iterable[Dict[str, Any]]) -> Dict[str, Any]:
+    """Select the best deterministic entity to keep active."""
+    ordered = sorted(
+        entities,
+        key=lambda entity: (
+            not str(entity["RowKey"]).startswith("groupme-"),
+            -_confidence(entity),
+            -_completeness(entity),
+            -_timestamp(entity),
+            str(entity["RowKey"]),
+        ),
+    )
+    return ordered[0]
+
+
+def build_cleanup_plan(
+    entities: Iterable[Dict[str, Any]],
+) -> List[Tuple[str, Dict[str, Any], List[Dict[str, Any]]]]:
+    """Return duplicate groups with one keeper and one removal list."""
+    groups: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
+    for entity in entities:
+        groupme_id = str(entity.get("groupme_id", "")).strip()
+        if groupme_id:
+            groups[groupme_id].append(entity)
+
+    plan = []
+    for groupme_id, group in groups.items():
+        if len(group) < 2:
+            continue
+        keeper = select_keeper(group)
+        removals = [
+            entity for entity in group if entity["RowKey"] != keeper["RowKey"]
+        ]
+        plan.append((groupme_id, keeper, removals))
+
+    return sorted(plan, key=lambda item: item[0])
+
+
+def copy_to_backup(
+    table_client: TableClient,
+    entity: Dict[str, Any],
+    backup_partition: str,
+    cleanup_time: str,
+) -> None:
+    """Copy one active entity to the recovery partition."""
+    backup = {
+        key: value
+        for key, value in entity.items()
+        if key not in SYSTEM_FIELDS
+    }
+    backup.update(
+        {
+            "PartitionKey": backup_partition,
+            "RowKey": entity["RowKey"],
+            "cleanup_original_partition": ACTIVE_PARTITION,
+            "cleanup_time_utc": cleanup_time,
+        }
+    )
+    table_client.upsert_entity(backup)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Find duplicate active responder entities by GroupMe message ID. "
+            "The default mode does not change data."
+        )
+    )
+    parser.add_argument("--account-name", required=True)
+    parser.add_argument("--table-name", default="ResponderMessages")
+    parser.add_argument(
+        "--account-key-env",
+        default="AZURE_STORAGE_KEY",
+        help="Environment variable that contains the storage account key.",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Move excess entities to a recovery partition.",
+    )
+    parser.add_argument(
+        "--backup-partition",
+        help="Recovery partition name. This value is required with --apply.",
+    )
+    parser.add_argument(
+        "--expected-removals",
+        type=int,
+        help=(
+            "Expected excess entity count. This value is required with --apply "
+            "and stops cleanup if the live count changed."
+        ),
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    account_key = os.getenv(args.account_key_env, "")
+    if not account_key:
+        print(
+            f"Set {args.account_key_env} before you run this command.",
+            file=sys.stderr,
+        )
+        return 2
+
+    if args.apply and not args.backup_partition:
+        print("--backup-partition is required with --apply.", file=sys.stderr)
+        return 2
+    if args.apply and args.backup_partition == ACTIVE_PARTITION:
+        print(
+            f"--backup-partition cannot be {ACTIVE_PARTITION}.",
+            file=sys.stderr,
+        )
+        return 2
+    if args.apply and args.expected_removals is None:
+        print("--expected-removals is required with --apply.", file=sys.stderr)
+        return 2
+
+    credential = AzureNamedKeyCredential(args.account_name, account_key)
+    table_client = TableClient(
+        endpoint=f"https://{args.account_name}.table.core.windows.net",
+        table_name=args.table_name,
+        credential=credential,
+    )
+    entities = list(
+        table_client.query_entities(
+            f"PartitionKey eq '{ACTIVE_PARTITION}'"
+        )
+    )
+    plan = build_cleanup_plan(entities)
+    removal_count = sum(len(removals) for _, _, removals in plan)
+
+    print(f"Active entities: {len(entities)}")
+    print(f"Duplicate GroupMe IDs: {len(plan)}")
+    print(f"Excess entities: {removal_count}")
+
+    if not args.apply:
+        print("Dry run complete. No data changed.")
+        return 0
+    if removal_count != args.expected_removals:
+        print(
+            "Cleanup stopped because the excess entity count changed. "
+            f"Expected {args.expected_removals}, found {removal_count}.",
+            file=sys.stderr,
+        )
+        return 1
+
+    cleanup_time = datetime.now(timezone.utc).isoformat()
+    moved = 0
+    for _, _, removals in plan:
+        for entity in removals:
+            copy_to_backup(
+                table_client,
+                entity,
+                args.backup_partition,
+                cleanup_time,
+            )
+            table_client.delete_entity(
+                ACTIVE_PARTITION,
+                entity["RowKey"],
+            )
+            moved += 1
+
+    remaining_entities = list(
+        table_client.query_entities(
+            f"PartitionKey eq '{ACTIVE_PARTITION}'"
+        )
+    )
+    remaining_plan = build_cleanup_plan(remaining_entities)
+
+    print(f"Moved entities: {moved}")
+    print(f"Recovery partition: {args.backup_partition}")
+    print(f"Remaining duplicate GroupMe IDs: {len(remaining_plan)}")
+    return 0 if not remaining_plan else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Process one queue message at a time and renew its visibility during slow AI extraction.
- Derive a stable storage row key from the GroupMe group and message IDs.
- Use an atomic Azure Table upsert for normal message ingestion.
- Add a dry-run-first, recoverable production duplicate cleanup utility.
- Remove the custom Static Web Apps authentication block that Azure rejects on the PPE and production Free SKUs. The React application continues to use MSAL and the API continues to validate its tokens.
- Update GitHub, Docker, and Azure workflow actions to Node 24-compatible majors.

## Root cause

Production workers received batches of five messages with a 30-second visibility timeout. AI processing was serial and could exceed the timeout. Other replicas then received the same messages. Each retry used a new UUID row key, and deletion with the expired queue receipt failed. The storage path also rewrote the full active partition.

## Verification

- PR CI: passed on commit `f57cf0b`.
- Backend curated suite: passed.
- Frontend suite: passed.
- Production frontend build: passed.
- GitHub workflow lint: passed for CI, PPE deployment, production deployment, and Copilot setup.
- PPE deployment workflow: passed with no Node runtime deprecation annotations.
- PPE deployment covered OIDC login, immutable backend image deployment, Container App update, and Static Web Apps deployment.
- PPE health: Container App revision healthy, API healthy, and `preprod.scvsar.app` returned 200.
- PPE queue regression: 25 queued messages produced 25 stored rows, 25 unique source IDs, zero duplicate source IDs, and an empty queue.
- PPE cleanup: all 25 synthetic rows removed; zero remain.
- Production cleanup dry run: 662 active rows, 61 duplicate GroupMe IDs, 241 excess rows. No production data changed.

## Deployment and cleanup

After merge, confirm that the production workflow deploys this commit and that the new revision is healthy. Then run the cleanup utility with the reviewed excess count and a named recovery partition. The utility stops if the live count changed. It copies every removed row to the recovery partition before it deletes the active row.

Fixes #21