### PR TITLE
Fail closed when production backend change detection cannot run

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -107,6 +107,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Resolve parameters
         id: params
@@ -152,13 +154,17 @@ jobs:
               BACKEND_DEPLOY=true
               REASON="No previous SHA available"
             else
-              CHANGED_FILES=$(git diff --name-only "$BEFORE" "$AFTER" || true)
-              echo "Changed files:"
-              echo "$CHANGED_FILES"
-
-              if echo "$CHANGED_FILES" | grep -E '^(backend/|Dockerfile\.backend|\.github/workflows/deploy-prod\.yml)' >/dev/null; then
+              if ! CHANGED_FILES=$(git diff --name-only "$BEFORE" "$AFTER"); then
                 BACKEND_DEPLOY=true
-                REASON="Backend-related files changed"
+                REASON="Could not inspect changed files"
+              else
+                echo "Changed files:"
+                echo "$CHANGED_FILES"
+
+                if echo "$CHANGED_FILES" | grep -E '^(backend/|Dockerfile\.backend|\.github/workflows/deploy-prod\.yml)' >/dev/null; then
+                  BACKEND_DEPLOY=true
+                  REASON="Backend-related files changed"
+                fi
               fi
             fi
           fi


### PR DESCRIPTION
## Summary

- Fetch full history in the production deployment job.
- Treat a failed commit diff as a reason to deploy the backend.
- Preserve the existing behavior that skips backend deployment for verified frontend-only changes.

## Incident

The automatic production run for merge commit `f62ec9e` could not resolve the previous main commit because the deploy job used a shallow checkout. The logged `git diff` failed with `fatal: bad object`, but `|| true` converted that failure into an empty changed-file list. The workflow then skipped the backend deployment and deployed only the Static Web App.

The production worker was deployed through the workflow's explicit immutable-image path as revision `prod-f62ec9ee`. The revision is healthy. The API and dashboard are responding, the queue is empty, and sampled worker logs contain no processing, delete, or lease-renewal failures.

## Cleanup result

After the fixed worker was live:

- 241 excess active rows moved to recovery partition `duplicate-cleanup-20260723-f62ec9ee`.
- 421 active rows remain.
- Zero duplicate GroupMe IDs remain.
- All 241 recovery rows contain cleanup trace metadata.

## Verification

- `actionlint .github/workflows/deploy-prod.yml`: passed.
- `git diff --check`: passed.
- PR backend and frontend checks: passed.
- The merge range from `c181519` to `f62ec9e` contains 14 changed files and matches the backend deployment filter.

Related to #21 and #22.